### PR TITLE
Alter code around line 706 to fix compilation errors.

### DIFF
--- a/HUSKYLENS/HUSKYLENS.h
+++ b/HUSKYLENS/HUSKYLENS.h
@@ -703,7 +703,8 @@ public:
     {
         Protocol_t protocol;
         uint8_t length = version.length();
-        uint8_t data[length + 2] = {length};
+        uint8_t data[length + 2];
+        data[0]=length;
         version.toCharArray((char *)data + 1, length + 1);
         protocol.firmwareVersion.length = length + 1;
         protocol.firmwareVersion.data = data;


### PR DESCRIPTION
I changed the code at line 706 from

uint8_t length = version.length();
uint8_t data[length + 2] = {length};

to

uint8_t length = version.length();
uint8_t data[length +2];
data[0]=length;

This change fixes the following error

"libraries\HUSKYLENS/HUSKYLENS.h:706:43: error: variable-sized object 'data' may not be initialized
         uint8_t data[length + 2] = {length};
                                           ^"

This error would prevent any code that includes the HUSKYLENS.h library from compiling.