### PR TITLE
Fix for checkFirmwareVersion() and husky_lens_protocol_write_begin() return type errors

### DIFF
--- a/HUSKYLENS/HUSKYLENS.h
+++ b/HUSKYLENS/HUSKYLENS.h
@@ -696,7 +696,7 @@ public:
 
     #define HUSKYLENS_FIRMWARE_VERSION "0.4.1"
     bool checkFirmwareVersion(){
-       writeFirmwareVersion(HUSKYLENS_FIRMWARE_VERSION);
+       return writeFirmwareVersion(HUSKYLENS_FIRMWARE_VERSION);
     }
 
      bool writeFirmwareVersion(String version)

--- a/HUSKYLENS/HuskyLensProtocolCore.c
+++ b/HUSKYLENS/HuskyLensProtocolCore.c
@@ -132,7 +132,7 @@ uint8_t* husky_lens_protocol_write_begin(uint8_t command){
     send_buffer[ADDRESS_INDEX] = 0x11;
     send_buffer[COMMAND_INDEX] = command;
     send_index = CONTENT_INDEX;
-    return &send_buffer;
+    return send_buffer;
 }
 
 void husky_lens_protocol_write_uint8(uint8_t content){


### PR DESCRIPTION
fixed the return type for checkFirmwareVersion() and husky_lens_protocol_write_begin()

Addresses issues #22 and #17 